### PR TITLE
deps: bump security-framework to 3.4 and core-foundation to 0.10

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3382,7 +3382,7 @@ version = "0.9.1"
 dependencies = [
  "block2",
  "chrono",
- "core-foundation 0.9.4",
+ "core-foundation 0.10.1",
  "futures",
  "image",
  "keyring",
@@ -3393,7 +3393,7 @@ dependencies = [
  "objc2-user-notifications",
  "open",
  "reqwest",
- "security-framework 2.11.1",
+ "security-framework 3.4.0",
  "security-framework-sys",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,9 +33,9 @@ image = "0.25"
 tauri-plugin-global-shortcut = "2.3.1"
 tauri-plugin-notification = "2.3.3"
 keyring = { version = "3.6.3", features = ["apple-native"] }
-security-framework = "2"
+security-framework = "3"
 security-framework-sys = "2"
-core-foundation = "0.9"
+core-foundation = "0.10"
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSPanel", "NSResponder", "NSWindow", "NSApplication", "NSRunningApplication", "NSWorkspace", "NSScreen", "NSEvent", "NSSound"] }
 objc2-core-foundation = "0.3"


### PR DESCRIPTION
## Summary
- Bumps `security-framework` from 2.11.1 to 3.4.0
- Bumps `core-foundation` from 0.9.4 to 0.10.1
- These must be upgraded together — security-framework 3.x depends on core-foundation 0.10, and upgrading either alone causes a `TCFType` trait mismatch at compile time

Supersedes #27 and #28 (both closed).

## Test plan
- [x] `cargo check` passes
- [x] All 103 Rust tests pass
- [x] All 423 TypeScript tests pass
- [x] Pre-commit hooks (a11y, tests) pass