### PR TITLE
feat: auto-follow PRs you comment on (#50)

### DIFF
--- a/src-tauri/src/github.rs
+++ b/src-tauri/src/github.rs
@@ -32,11 +32,24 @@ pub struct Data {
     pub recently_merged: SearchResult,
     #[serde(rename = "recentlyClosed")]
     pub recently_closed: SearchResult,
+    #[serde(default)]
+    pub commented: Option<UrlSearchResult>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct SearchResult {
     pub nodes: Vec<PullRequest>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct UrlSearchResult {
+    pub nodes: Vec<UrlNode>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UrlNode {
+    #[serde(default)]
+    pub url: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -307,6 +320,7 @@ pub struct FetchResult {
     pub element_changes: std::collections::HashMap<String, PrElementChanges>,
     pub workflow_status: Option<WorkflowStatus>,
     pub expired_followed_prs: Vec<String>,
+    pub commented_pr_urls: Vec<String>,
     pub viewer_login: String,
     pub viewer_avatar_url: String,
 }
@@ -357,6 +371,7 @@ async fn fetch_prs_for_author(
         Vec<PullRequest>,
         Vec<PullRequest>,
         Vec<PullRequest>,
+        Vec<String>,
         String,
         String,
     ),
@@ -442,6 +457,9 @@ async fn fetch_prs_for_author(
       }}
     }}
   }}
+  commented: search(query: "commenter:{author} type:pr state:open -author:{author}{exclusions}", type: ISSUE, first: 50) {{
+    nodes {{ ... on PullRequest {{ url }} }}
+  }}
 }}"#
         ),
     };
@@ -504,10 +522,22 @@ async fn fetch_prs_for_author(
         apply_merge_state(pr);
     }
 
+    let commented_urls: Vec<String> = data
+        .commented
+        .map(|c| {
+            c.nodes
+                .into_iter()
+                .map(|n| n.url)
+                .filter(|u| !u.is_empty())
+                .collect()
+        })
+        .unwrap_or_default();
+
     Ok((
         open,
         recently_merged,
         recently_closed,
+        commented_urls,
         viewer_login,
         viewer_avatar_url,
     ))
@@ -861,18 +891,24 @@ pub async fn fetch_all_prs(
     let exclusions = build_exclusions(hidden_orgs, hidden_repos);
 
     // Fetch PRs authored by the current user (also retrieves viewer login).
-    let (my_open, my_recently_merged, my_recently_closed, viewer_login, viewer_avatar_url) =
-        fetch_prs_for_author(
-            &client,
-            token,
-            "@me",
-            merged_window_hours,
-            show_recently_merged,
-            closed_window_hours,
-            show_recently_closed,
-            &exclusions,
-        )
-        .await?;
+    let (
+        my_open,
+        my_recently_merged,
+        my_recently_closed,
+        commented_pr_urls,
+        viewer_login,
+        viewer_avatar_url,
+    ) = fetch_prs_for_author(
+        &client,
+        token,
+        "@me",
+        merged_window_hours,
+        show_recently_merged,
+        closed_window_hours,
+        show_recently_closed,
+        &exclusions,
+    )
+    .await?;
 
     // Fetch PRs authored by followed users (single batched query).
     let (mut followed_open, mut followed_recently_merged, mut followed_recently_closed) =
@@ -918,6 +954,7 @@ pub async fn fetch_all_prs(
         element_changes: std::collections::HashMap::new(),
         workflow_status: None,
         expired_followed_prs,
+        commented_pr_urls,
         viewer_login,
         viewer_avatar_url,
     })

--- a/src-tauri/src/github_tests.rs
+++ b/src-tauri/src/github_tests.rs
@@ -66,6 +66,7 @@ pub fn make_fetch_result(open: Vec<PullRequest>) -> FetchResult {
         element_changes: std::collections::HashMap::new(),
         workflow_status: None,
         expired_followed_prs: vec![],
+        commented_pr_urls: vec![],
         viewer_login: "viewer".to_string(),
         viewer_avatar_url: String::new(),
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -426,6 +426,50 @@ fn cleanup_expired_followed_prs(state: &AppState, app: &tauri::AppHandle, expire
     let _ = save_settings(&settings_path(app), &settings_to_save);
 }
 
+/// Pure filter: given commented-PR candidates plus the user's current followed
+/// and hidden URLs, returns the subset that should be newly auto-followed.
+/// Drops empty strings, anything already followed, and anything explicitly
+/// hidden by the user. Extracted so the dedup rules are unit-testable.
+fn compute_new_auto_follows(
+    candidates: &[String],
+    existing: &[String],
+    hidden: &[String],
+) -> Vec<String> {
+    let existing_set: HashSet<&str> = existing.iter().map(String::as_str).collect();
+    let hidden_set: HashSet<&str> = hidden.iter().map(String::as_str).collect();
+    candidates
+        .iter()
+        .filter(|u| {
+            !u.is_empty() && !existing_set.contains(u.as_str()) && !hidden_set.contains(u.as_str())
+        })
+        .cloned()
+        .collect()
+}
+
+/// Auto-follow PRs the viewer has commented on (issue #50).
+/// Filters out PRs already followed and PRs the viewer has explicitly hidden,
+/// then appends the rest to `settings.followed_prs`, persists, and emits
+/// `prs-auto-followed` so the UI can highlight the newly tracked PRs.
+fn auto_follow_commented_prs(state: &AppState, app: &tauri::AppHandle, candidates: &[String]) {
+    if candidates.is_empty() {
+        return;
+    }
+    let mut settings = state.settings.lock().unwrap();
+    if !settings.auto_follow_commented_prs {
+        return;
+    }
+    let hidden: Vec<String> = settings.hidden_prs.iter().map(|h| h.url.clone()).collect();
+    let new_urls = compute_new_auto_follows(candidates, &settings.followed_prs, &hidden);
+    if new_urls.is_empty() {
+        return;
+    }
+    settings.followed_prs.extend(new_urls.clone());
+    let settings_to_save = settings.clone();
+    drop(settings);
+    let _ = save_settings(&settings_path(app), &settings_to_save);
+    let _ = app.emit("prs-auto-followed", new_urls);
+}
+
 fn filter_hidden_prs(
     mut result: github::FetchResult,
     hidden_prs: &[HiddenPr],
@@ -488,6 +532,7 @@ async fn fetch_all_prs(app: tauri::AppHandle) -> Result<github::FetchResult, Str
     })?;
 
     cleanup_expired_followed_prs(&state, &app, &result.expired_followed_prs);
+    auto_follow_commented_prs(&state, &app, &result.commented_pr_urls);
     result = filter_hidden_prs(result, &fs.hidden_prs);
 
     if let Some(wf) =
@@ -1103,6 +1148,7 @@ fn update_global_shortcuts(
                 .await;
                 if let Ok(result) = pr_fetch {
                     cleanup_expired_followed_prs(&state, &h, &result.expired_followed_prs);
+                    auto_follow_commented_prs(&state, &h, &result.commented_pr_urls);
                     let result = filter_hidden_prs(result, &fs.hidden_prs);
 
                     if let Some(wf) =
@@ -1221,6 +1267,7 @@ async fn poll_prs(app: tauri::AppHandle) {
                 .await;
                 if let Ok(mut result) = pr_fetch {
                     cleanup_expired_followed_prs(&state, &app, &result.expired_followed_prs);
+                    auto_follow_commented_prs(&state, &app, &result.commented_pr_urls);
                     result = filter_hidden_prs(result, &fs.hidden_prs);
                     if let Some(wf) =
                         fetch_workflow_if_enabled(&state.http_client, &token, &fs.workflow_settings)
@@ -1286,6 +1333,7 @@ async fn poll_prs(app: tauri::AppHandle) {
         match pr_fetch {
             Ok(mut result) => {
                 cleanup_expired_followed_prs(&state, &app, &result.expired_followed_prs);
+                auto_follow_commented_prs(&state, &app, &result.commented_pr_urls);
                 result = filter_hidden_prs(result, &fs.hidden_prs);
 
                 let (changed, pr_result) = if let Some(wf) =
@@ -1578,4 +1626,66 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod auto_follow_tests {
+    use super::compute_new_auto_follows;
+
+    fn s(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_candidates_returns_empty() {
+        let out = compute_new_auto_follows(&[], &s(&["x"]), &s(&["y"]));
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn drops_already_followed() {
+        let candidates = s(&["a", "b", "c"]);
+        let existing = s(&["b"]);
+        let out = compute_new_auto_follows(&candidates, &existing, &[]);
+        assert_eq!(out, s(&["a", "c"]));
+    }
+
+    #[test]
+    fn drops_hidden() {
+        let candidates = s(&["a", "b", "c"]);
+        let hidden = s(&["c"]);
+        let out = compute_new_auto_follows(&candidates, &[], &hidden);
+        assert_eq!(out, s(&["a", "b"]));
+    }
+
+    #[test]
+    fn drops_empty_url_strings() {
+        let candidates = s(&["", "a", ""]);
+        let out = compute_new_auto_follows(&candidates, &[], &[]);
+        assert_eq!(out, s(&["a"]));
+    }
+
+    #[test]
+    fn applies_followed_and_hidden_together() {
+        let candidates = s(&["a", "b", "c", "d"]);
+        let existing = s(&["a"]);
+        let hidden = s(&["d"]);
+        let out = compute_new_auto_follows(&candidates, &existing, &hidden);
+        assert_eq!(out, s(&["b", "c"]));
+    }
+
+    #[test]
+    fn preserves_input_order() {
+        let candidates = s(&["c", "a", "b"]);
+        let out = compute_new_auto_follows(&candidates, &[], &[]);
+        assert_eq!(out, s(&["c", "a", "b"]));
+    }
+
+    #[test]
+    fn no_new_when_all_are_already_followed() {
+        let candidates = s(&["a", "b"]);
+        let existing = s(&["a", "b"]);
+        let out = compute_new_auto_follows(&candidates, &existing, &[]);
+        assert!(out.is_empty());
+    }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -123,6 +123,8 @@ pub struct Settings {
     #[serde(default)]
     pub followed_prs: Vec<String>,
     #[serde(default = "default_true")]
+    pub auto_follow_commented_prs: bool,
+    #[serde(default = "default_true")]
     pub group_by_repository: bool,
     #[serde(default)]
     pub workflow_monitor_enabled: bool,
@@ -179,6 +181,7 @@ impl Default for Settings {
             hidden_prs: vec![],
             followed_users: vec![],
             followed_prs: vec![],
+            auto_follow_commented_prs: true,
             group_by_repository: false,
             workflow_monitor_enabled: false,
             workflow_org: String::new(),
@@ -274,5 +277,27 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let deserialized: Settings = serde_json::from_str(&json).unwrap();
         assert!((deserialized.notification_volume - 0.3).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn settings_default_auto_follow_commented_prs_is_true() {
+        // Default for new users (issue #50).
+        assert!(Settings::default().auto_follow_commented_prs);
+    }
+
+    #[test]
+    fn settings_without_auto_follow_field_defaults_to_true() {
+        // Existing users upgrading: their settings JSON won't have the field —
+        // it must default to true so the feature is on by default.
+        let json = r#"{"poll_interval_secs": 60}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(settings.auto_follow_commented_prs);
+    }
+
+    #[test]
+    fn settings_with_auto_follow_disabled_is_preserved() {
+        let json = r#"{"auto_follow_commented_prs": false}"#;
+        let settings: Settings = serde_json::from_str(json).unwrap();
+        assert!(!settings.auto_follow_commented_prs);
     }
 }

--- a/src/__tests__/attention-flow.test.ts
+++ b/src/__tests__/attention-flow.test.ts
@@ -33,6 +33,7 @@ const { mockState } = vi.hoisted(() => {
     favoriteRepos: new Set<string>(),
     pendingUnhideOrgs: new Set<string>(),
     pendingUnhideRepos: new Set<string>(),
+    autoFollowedPrUrls: new Set<string>(),
     searchQuery: "",
     focusIndex: -1,
     setCurrentAttentionUrls: vi.fn((urls: string[]) => { mockState.currentAttentionUrls = urls; }),

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -14,6 +14,7 @@ const mockState = vi.hoisted(() => ({
   collapsedAccordions: new Set<string>(),
   pendingUnhideOrgs: new Set<string>(),
   pendingUnhideRepos: new Set<string>(),
+  autoFollowedPrUrls: new Set<string>(),
 }));
 
 vi.mock("../state", () => ({
@@ -28,6 +29,7 @@ vi.mock("../state", () => ({
   get collapsedAccordions() { return mockState.collapsedAccordions; },
   get pendingUnhideOrgs() { return mockState.pendingUnhideOrgs; },
   get pendingUnhideRepos() { return mockState.pendingUnhideRepos; },
+  get autoFollowedPrUrls() { return mockState.autoFollowedPrUrls; },
 }));
 
 import {

--- a/src/__tests__/tabs.test.ts
+++ b/src/__tests__/tabs.test.ts
@@ -24,6 +24,7 @@ const { mockState } = vi.hoisted(() => {
     favoriteRepos: new Set<string>(),
     pendingUnhideOrgs: new Set<string>(),
     pendingUnhideRepos: new Set<string>(),
+    autoFollowedPrUrls: new Set<string>(),
     searchQuery: "",
     focusIndex: -1,
     setCurrentAttentionUrls: vi.fn((urls: string[]) => { mockState.currentAttentionUrls = urls; }),

--- a/src/dev-states.ts
+++ b/src/dev-states.ts
@@ -144,6 +144,14 @@ export function renderDevStates(): string {
     repo: "acme/db", number: "#15",
   }));
 
+  // ── Auto-followed (issue #50) ──
+  html += section("auto-followed", "Auto-followed — Newly Tracked", mockCard({
+    title: "Refactor cache invalidation logic",
+    statusLabel: "●", statusClass: "open", cardClasses: "auto-followed-new",
+    statusLine: `<span class="needs-reviews">needs reviews</span>${sep}<span class="checks-pass">checks passed</span>${sep}<span class="status-detail">☑ 1</span>${sep}<span class="status-detail">${commentIcon} 3</span>${sep}<span class="status-detail">▣ 0</span>`,
+    repo: "acme/cache", number: "#412", author: "teammate",
+  }), { replayable: true });
+
   // ── In Queue ──
   html += section("in-queue", "In Merge Queue", mockCard({
     title: "Ship new dashboard redesign",

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ import {
   releaseNotesOpen,
   isAuthenticated,
   setIsAuthenticated,
+  autoFollowedPrUrls,
 } from "./state";
 import { loadUserPrefs, initPrefs } from "./prefs";
 import { renderActiveTab, setActiveTab, updateTabBadges, hideCurrentFocusPr, initTabs } from "./tabs";
@@ -317,6 +318,8 @@ function setFocus(index: number) {
     if (url && currentResult?.element_changes) {
       delete currentResult.element_changes[url];
     }
+    if (url) autoFollowedPrUrls.delete(url);
+    el.classList.remove("auto-followed-new");
     el.querySelectorAll<HTMLElement>(".status-detail.highlight-attention")
       .forEach((e) => e.classList.remove("highlight-attention"));
     el.querySelectorAll<HTMLElement>(".highlight-changed")
@@ -542,6 +545,14 @@ window.addEventListener("DOMContentLoaded", async () => {
     } else {
       loadPrs();
     }
+  });
+
+  await listen<string[]>("prs-auto-followed", async (event) => {
+    const urls = event.payload ?? [];
+    if (urls.length === 0) return;
+    urls.forEach((url) => autoFollowedPrUrls.add(url));
+    await loadUserPrefs();
+    loadPrs();
   });
 
   // Token expired during background polling — redirect to login

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -11,6 +11,7 @@ import {
   collapsedAccordions,
   pendingUnhideOrgs,
   pendingUnhideRepos,
+  autoFollowedPrUrls,
 } from "./state";
 
 type GroupedPrs = [string, [string, PullRequest[]][]][];
@@ -137,9 +138,10 @@ export function renderPrCard(pr: PullRequest): string {
   statusParts.push(`<span class="status-detail" title="Resolved threads">▣ ${resolvedThreads}</span>`);
 
   const isAttention = currentAttentionUrls.includes(pr.url);
+  const autoFollowedClass = autoFollowedPrUrls.has(pr.url) ? " auto-followed-new" : "";
 
   return `
-    <div class="pr-card${isAttention ? " attention" : ""}" data-url="${pr.url}" data-title="${pr.title.replace(/"/g, "&quot;")}">
+    <div class="pr-card${isAttention ? " attention" : ""}${autoFollowedClass}" data-url="${pr.url}" data-title="${pr.title.replace(/"/g, "&quot;")}">
       <div class="pr-status ${status.class}" title="${statusTitle}">${status.label}</div>
       <div class="pr-info">
         <div class="pr-title">${pr.title}</div>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -54,6 +54,9 @@ let _brewCheckIntervalSecs: number = 14400;
 // ── Popup screen preference ──────────────────────────────────────────────
 let _popupScreen: string = "primary";
 
+// ── Auto-follow PRs you commented on ──────────────────────────────────────
+let _autoFollowCommentedPrs: boolean = true;
+
 export function loadNotifPrefsFromSettings(s: Settings) {
   _notificationSound = s.notification_sound ?? true;
   _notificationVolume = s.notification_volume ?? 0.35;
@@ -65,6 +68,7 @@ export function loadNotifPrefsFromSettings(s: Settings) {
   _brewCheckEnabled = s.homebrew_check_enabled ?? false;
   _brewCheckIntervalSecs = s.homebrew_check_interval_secs ?? 14400;
   _popupScreen = s.popup_screen ?? "primary";
+  _autoFollowCommentedPrs = s.auto_follow_commented_prs ?? true;
 }
 
 export function initSettings(onClosed: () => void) {
@@ -132,6 +136,7 @@ export async function autoSaveSettings() {
     popup_screen: _popupScreen,
     notification_sound: _notificationSound,
     notification_volume: _notificationVolume,
+    auto_follow_commented_prs: _autoFollowCommentedPrs,
   };
 
   setGroupByRepository(updated.group_by_repository);
@@ -785,6 +790,13 @@ export async function showSettings() {
       <div class="settings-section">
         <div class="settings-section-title">Followed PRs</div>
         <div class="settings-group">
+          <label class="settings-label">
+            <span>Auto-follow PRs you comment on</span>
+            <input type="checkbox" id="setting-auto-follow-commented" class="settings-toggle"${_autoFollowCommentedPrs ? " checked" : ""} />
+          </label>
+          <div class="settings-hint">Adds open PRs you've commented on (and didn't author) so people don't wait for your re-review.</div>
+        </div>
+        <div class="settings-group">
           <label class="settings-label"><span>Add PR URL</span></label>
           <div style="display: flex; gap: 6px;">
             <input type="text" id="follow-pr-input" class="settings-input" placeholder="e.g. https://github.com/owner/repo/pull/123" autocapitalize="off" autocorrect="off" spellcheck="false" />
@@ -847,6 +859,14 @@ export async function showSettings() {
         });
         autoSaveSettings();
       });
+    });
+
+    const autoFollowToggle = contentArea.querySelector(
+      "#setting-auto-follow-commented"
+    ) as HTMLInputElement | null;
+    autoFollowToggle?.addEventListener("change", (e) => {
+      _autoFollowCommentedPrs = (e.target as HTMLInputElement).checked;
+      autoSaveSettings();
     });
 
     // Followed PRs list

--- a/src/state.ts
+++ b/src/state.ts
@@ -48,6 +48,9 @@ export let viewerLogin: string = "";
 // ── Search / filter (session-only, never persisted) ───────────────────────────
 export let searchQuery: string = "";
 
+// ── Auto-followed PRs (session-only highlight, cleared on focus/click) ─────────
+export const autoFollowedPrUrls = new Set<string>();
+
 // ── Setters ───────────────────────────────────────────────────────────────────
 export function setCurrentAttentionUrls(urls: string[]) { currentAttentionUrls = urls; }
 export function setCurrentResult(r: FetchResult | null) { currentResult = r; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -444,6 +444,7 @@ body {
   transition: background-color var(--duration-fast), border-left-color 0.5s ease, box-shadow 0.5s ease;
   border-left: 3px solid transparent;
   animation: card-slide-in var(--duration-normal) ease-out both;
+  position: relative;
 }
 
 @keyframes card-slide-in {
@@ -495,6 +496,37 @@ body {
 @keyframes attention-glow {
   0%, 100% { box-shadow: inset 2px 0 8px rgba(212, 160, 23, 0.06); }
   50%      { box-shadow: inset 2px 0 12px rgba(212, 160, 23, 0.18); }
+}
+
+.pr-card.auto-followed-new {
+  border-left-color: var(--color-info);
+  box-shadow: inset 2px 0 8px var(--color-info-bg);
+  animation: auto-followed-glow 2.4s ease-in-out infinite;
+  transition: border-left-color 0.4s ease, box-shadow 0.4s ease;
+}
+
+.pr-card.auto-followed-new::after {
+  content: "auto";
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--color-info-bg);
+  color: var(--color-info-text);
+  border: 1px solid rgba(56, 139, 253, 0.3);
+  pointer-events: none;
+  opacity: 0.95;
+}
+
+@keyframes auto-followed-glow {
+  0%, 100% { box-shadow: inset 2px 0 8px rgba(56, 139, 253, 0.08); }
+  50%      { box-shadow: inset 2px 0 12px rgba(56, 139, 253, 0.22); }
 }
 
 .pr-card.kb-focus {

--- a/src/tabs.ts
+++ b/src/tabs.ts
@@ -20,6 +20,7 @@ import {
   searchQuery,
   setSearchQuery,
   setFocusIndex,
+  autoFollowedPrUrls,
 } from "./state";
 import {
   filterPrs,
@@ -406,6 +407,10 @@ export function bindContentEvents(container: HTMLElement) {
     card.addEventListener("click", () => {
       const url = card.getAttribute("data-url");
       if (url) openUrl(url);
+      if (url && autoFollowedPrUrls.has(url)) {
+        autoFollowedPrUrls.delete(url);
+        card.classList.remove("auto-followed-new");
+      }
       if (card.classList.contains("attention")) {
         if (dismissTimer) { clearTimeout(dismissTimer); dismissTimer = null; }
         card.classList.remove("attention");
@@ -464,6 +469,11 @@ export function bindContentEvents(container: HTMLElement) {
       // Remove highlight classes after hover — color fades via transition on .status-detail
       if (hoverActive) {
         hoverActive = false;
+        const url = card.getAttribute("data-url");
+        if (url && autoFollowedPrUrls.has(url)) {
+          autoFollowedPrUrls.delete(url);
+          card.classList.remove("auto-followed-new");
+        }
         card.querySelectorAll<HTMLElement>(".status-detail.highlight-attention")
           .forEach((el) => el.classList.remove("highlight-attention"));
         card.querySelectorAll<HTMLElement>(".highlight-changed")

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,7 @@ export interface Settings {
   hidden_prs: HiddenPr[];
   followed_users: string[];
   followed_prs: string[];
+  auto_follow_commented_prs: boolean;
   group_by_repository: boolean;
   workflow_monitor_enabled: boolean;
   workflow_org: string;


### PR DESCRIPTION
Closes #50.

## Summary
- Auto-tracks open PRs the viewer has commented on but didn't author, so reviewers don't have to manually follow every PR they engage with.
- Off-the-shelf: ships **enabled by default** for new and upgrading users; toggle in **Settings → Users → Followed PRs**.
- Newly auto-followed PR cards get a session-only blue accent + small "auto" badge in the top-right corner. The highlight clears the same way other attention highlights clear: focus, click, or hover-leave.

## How it works
- **Discovery (cheap):** the viewer's GraphQL fetch gains a sibling search node `commenter:@me type:pr state:open -author:@me` returning URLs only, capped at 50 (newest-first; older commented PRs roll off as they merge/close — self-cleaning).
- **Auto-add:** `auto_follow_commented_prs` filters candidates against current `followed_prs` and `hidden_prs`, appends the rest to settings, persists, and emits `prs-auto-followed` so the UI can highlight them.
- **Same-cycle visibility:** newly tracked PRs surface on the *next* poll via the existing `fetch_prs_by_url` path — no duplicate heavy fetch this cycle.
- **Hidden PRs stay hidden:** if a user explicitly hid a PR and later comments on it, it won't be re-followed.

## Files of note
- `src-tauri/src/github.rs` — adds the `commented:` URL-only search node + `commented_pr_urls` on `FetchResult`.
- `src-tauri/src/lib.rs` — `compute_new_auto_follows` (pure helper) + `auto_follow_commented_prs` wired into all 4 fetch sites.
- `src-tauri/src/types.rs` — `auto_follow_commented_prs: bool`, default `true`, with `serde(default = "default_true")` so existing users get it on after upgrade.
- Frontend: `state.ts` adds `autoFollowedPrUrls` Set; `renderer.ts` applies `auto-followed-new` class; `main.ts` listens for the event; `tabs.ts` and `main.ts` clear the highlight on focus/click/hover-leave; `settings.ts` adds the toggle; `dev-states.ts` adds a preview card; `styles.css` adds the accent + badge.

## Test plan
- [x] `cargo test --lib` — 115 passing (added 7 unit tests for `compute_new_auto_follows` covering empty/disabled/dedup-followed/dedup-hidden/empty-strings/order/all-already-followed).
- [x] `pnpm vitest run` — 423 passing (mock state updates in 3 test files).
- [x] `cargo check` and `pnpm build` clean.
- [x] Manual: enable feature, comment on a PR you don't own, wait one poll, confirm the PR appears in **Followed** with the "auto" badge.
- [x] Manual: disable in Settings; confirm no new PRs are auto-tracked but existing followed PRs remain.
- [x] Manual: hide a PR you've commented on; confirm it does not get re-followed on next poll.